### PR TITLE
Installation script for Microsoft's Visual Studio Code

### DIFF
--- a/editors/extras/vscode.desktop
+++ b/editors/extras/vscode.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Visual Studio Code
+Comment=Visual Studio Code
+GenericName=Text Editor
+Exec=/usr/bin/code
+Icon=code
+Type=Application
+Terminal=false
+StartupNotify=true
+StartupWMClass=visual-studio-code
+Categories=Development;
+MimeType=text/plain;

--- a/editors/install-vscode.sh
+++ b/editors/install-vscode.sh
@@ -17,9 +17,9 @@ else
 	cd /home/$USER/Downloads && wget -q $vscodeUrl -O $tarballName # Download
 
 	echo "Bootstrapping..."
+	sudo rm -rf $vscodeDirRoot # Ensure existing VSCode content is removed
 	sudo mkdir -p $vscodeDirRoot # Ensure VSCode dir is created
 	cd $vscodeDirRoot # Go to VSCode directory
-	sudo rm -rf * # Ensure existing VSCode content is removed
 
 	echo "Unpackaging..."
 	sudo unzip -qq /home/$USER/Downloads/$tarballName

--- a/editors/install-vscode.sh
+++ b/editors/install-vscode.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+shellDir=$(pwd)
+vscodeUrl="https://go.microsoft.com/fwlink/?LinkID=620884"
+vscodeDirRoot="/opt/vscode-official"
+tarballName="vscode.zip"
+
+echo "Did you know, we already offer the open source community version of Visual Studio Code?"
+echo "Do you want to install that instead? (y/N)"
+read installOSS
+
+if [[ $installOSS == *"yes"* ]] # If we should install the OSS version
+then
+	sudo eopkg install vscode
+else
+	echo "Downloading Visual Studio Code from Microsoft"
+	cd /home/$USER/Downloads && wget -q $vscodeUrl -O $tarballName # Download
+
+	echo "Bootstrapping..."
+	sudo mkdir -p $vscodeDirRoot # Ensure VSCode dir is created
+	cd $vscodeDirRoot # Go to VSCode directory
+	sudo rm -rf * # Ensure existing VSCode content is removed
+
+	echo "Unpackaging..."
+	sudo unzip -qq /home/$USER/Downloads/$tarballName
+	sudo mv $vscodeDirRoot/VSCode-linux-x64/* $vscodeDirRoot/
+	sudo rmdir $vscodeDirRoot/VSCode-linux-x64
+
+	echo "Time travelling to the future."
+	sudo install -Dm644 $shellDir/extras/vscode.desktop /usr/share/applications/vscode.desktop
+	sudo cp $vscodeDirRoot/resources/app/resources/linux/code.png /usr/share/pixmaps/code.png
+	sudo ln -s $vscodeDirRoot/code /usr/bin/code
+	
+	rm /home/$USER/Downloads/$tarballName
+	echo "We're here!"
+fi


### PR DESCRIPTION
These commits provide an installation script that:
1. Provides the Microsoft-branded and enabled version of Visual Studio Code.
2. Prompts the user if they want to install the OSS version from the Solus repo instead.
3. Installs in a way that does **not** conflict with the OSS repo version.
